### PR TITLE
Fix link to Data and Software Guidelines.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 ## Table of Contents
 
-* [Data and Software Guidelines](blob/master/data-and-software-guidelines.md)
+* [Data and Software Guidelines](data-and-software-guidelines.md)


### PR DESCRIPTION
Wasn't working. Didn't need `blob/master`, I think.